### PR TITLE
Fix running in a subdirectory of the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,9 @@ this command works locally and output result to standard output.
   * One of `fatal`, `error`, `warn`, `info`, `debug`, `trace` or `silent`.
   * default value is `info`.
   * if you want to know this tool's internal states, set to `debug`.
-* `GITHUB_WORKSPACE`
+* `WORKING_DIR`
   * specify the working dir.
   * default value is `./`.
-  * if you use this tool as GitHub Actions, setting valid value automatically.
 
 # for developers
 ## setup

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,9 @@ const defaultPrefix = "package-update/";
 const defaultMessage = "update dependencies";
 
 const rawConfig = convict({
-  workspace: {
+  workingdir: {
     default: "./",
-    env: "GITHUB_WORKSPACE"
+    env: "WORKING_DIR"
   },
   token: {
     default: "",

--- a/src/git.ts
+++ b/src/git.ts
@@ -11,7 +11,7 @@ export default class Git {
   public async run(subcmd: string[] = []) {
     const msg = `git ${subcmd.join(" ")}`;
     this.conf.logger.debug(`BEGIN ${msg}`);
-    return execa("git", subcmd, { cwd: this.conf.get("workspace") })
+    return execa("git", subcmd, { cwd: this.conf.get("workingdir") })
       .then((value: execa.ExecaReturnValue) => {
         this.conf.logger.debug(`END   ${msg}`);
         if (value.failed) {


### PR DESCRIPTION
`GITHUB_WORKSPACE` is clobbered by GitHub if you try to set it yourself, so it's useless for allowing a user to override the working directory. Changing the name of the variable fixes this.

We don't need to use `GITHUB_WORKSPACE` as a fallback because GitHub actions already start us off in the project root by default.

Fixes #9.