### PR TITLE
feat: add node version control

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,9 @@
 # include required files with an exception
 !LICENSE
 !README.md
+
+# we need these files for node version control or build arguments
+!entrypoint.sh
+!docker
+!package.json
+!yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM node:latest
+# Use alpine because its super light weight
+FROM alpine:latest
 
-LABEL version="0.11.0"
-LABEL repository="https://github.com/taichi/actions-package-update"
-LABEL homepage="https://github.com/taichi/actions-package-update"
-LABEL maintainer="Sato Taichi <ryushi+actions@gmail.com>"
+# Copy files from the action repository to the filesystem path `/` of the container
+COPY . /actions-package-update
+COPY entrypoint.sh /entrypoint.sh
 
-LABEL "com.github.actions.name"="GitHub Action for package.json update."
-LABEL "com.github.actions.description"="Upgrades your package.json dependencies to the latest versions"
-LABEL "com.github.actions.icon"="corner-right-up"
-LABEL "com.github.actions.color"="gray-dark"
+RUN apk add --update --no-cache docker
+RUN ["chmod", "+x", "/entrypoint.sh"]
 
-RUN apt-get update && apt-get install -y --no-install-recommends -y git
-RUN yarn global add npm-check-updates
-RUN yarn global add actions-package-update
-
-ENTRYPOINT [ "actions-package-update" ]
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ or
   * `GITHUB_TOKEN`
     * GitHub personal access token is required for sending pull requests to your repository
     * [Creating an access token for command-line use](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
-  * `AUTHOR_NAME` and `AUTHOR_EMAIL` 
+  * `AUTHOR_NAME` and `AUTHOR_EMAIL`
     * this command use there variables for commit
   * `EXECUTE`
     * By default, actions-package-update runs in dry-run mode.
@@ -176,6 +176,9 @@ this command works locally and output result to standard output.
 * `WORKING_DIR`
   * specify the working dir.
   * default value is `./`.
+* `SET_NODE_VERSION`
+  * specify the node version you want to run on.
+  * default value is `latest`.
 
 # for developers
 ## setup
@@ -187,7 +190,7 @@ execute below commands on project root dir.
 ## release
 
 * release package to npmjs
-  
+
     yarn publish
 
 * edit Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+# SET_NODE_VERSION default is set in ../entrypoint.sh
+ARG SET_NODE_VERSION
+FROM node:${SET_NODE_VERSION}
+
+LABEL version="0.11.0"
+LABEL repository="https://github.com/taichi/actions-package-update"
+LABEL homepage="https://github.com/taichi/actions-package-update"
+LABEL maintainer="Sato Taichi <ryushi+actions@gmail.com>"
+
+LABEL "com.github.actions.name"="GitHub Action for package.json update."
+LABEL "com.github.actions.description"="Upgrades your package.json dependencies to the latest versions"
+LABEL "com.github.actions.icon"="corner-right-up"
+LABEL "com.github.actions.color"="gray-dark"
+
+RUN apt-get update && apt-get install -y --no-install-recommends -y git
+RUN yarn global add npm-check-updates
+RUN yarn global add actions-package-update
+
+# copy files from the action repository to the filesystem path `/` of the container
+COPY env.sh /env.sh
+COPY . /actions-package-update
+COPY entrypoint.sh /entrypoint.sh
+
+RUN ["chmod", "+x", "/entrypoint.sh"]
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -l
+
+# copy this container's enviroment original variables into this_env.sh
+# so we can restore them back if they are overwritten by env.sh
+export -p>this_env.sh
+
+# set this_env.sh shebang
+sed -i '1s/^/\#\!\/bin\/sh -l\n/' this_env.sh
+
+chmod +x /env.sh
+chmod +x /this_env.sh
+
+# set enviroment variables
+. /env.sh
+. /this_env.sh
+
+cd /actions-package-update
+
+actions-package-update

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,4 @@ sed -i '1s/^/\#\!\/bin\/sh -l\n/' env.sh
 
 # here we can make the construction of the image as customizable as we need
 # and if we need parameterizable values it is a matter of sending them as inputs
-docker build -t actions-package-update --build-arg SET_NODE_VERSION="$SET_NODE_VERSION"
-
-# run actions-package-update container
-docker run actions-package-update ${INPUT_ARGS}
+docker build -t actions-package-update --build-arg SET_NODE_VERSION="$SET_NODE_VERSION" . && docker run actions-package-update ${INPUT_ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh -l
+
+# set SET_NODE_VERSION env variable to latest if not defined
+SET_NODE_VERSION="${SET_NODE_VERSION:-latest}"
+
+echo "creating docker image running node version: $SET_NODE_VERSION"
+
+cd /actions-package-update
+
+# copy the files we will need to build the main/original docker container
+cp docker/Dockerfile Dockerfile
+cp docker/entrypoint.sh entrypoint.sh
+
+# .git is used by actions-package-update to query the repo that needs to be updated
+cp --recursive ${GITHUB_WORKSPACE}/.git .git
+
+rm -rf docker
+
+# copy this container's enviroment variables into env.sh so we can use them in the main container
+export -p >env.sh
+
+# set env.sh shebang
+sed -i '1s/^/\#\!\/bin\/sh -l\n/' env.sh
+
+# here we can make the construction of the image as customizable as we need
+# and if we need parameterizable values it is a matter of sending them as inputs
+docker build -t actions-package-update --build-arg SET_NODE_VERSION="$SET_NODE_VERSION"
+
+# run actions-package-update container
+docker run actions-package-update ${INPUT_ARGS}


### PR DESCRIPTION
One of my [actions](https://github.com/oslllo/potrace/actions/runs/563970267) failed because the package updater was running on a node version that was not supported by one of the packages that was pulled by NCU (node-check-update).

This will allow the user to control which version of node they
want to use when they run the action.

The current behavior locks the node version to `latest` which
may not be ideal for certain scenarios.

The setting is optional and defaults to `latest` so it should not
break any existing packages without the option set.

Tests: https://github.com/Ghustavh97/actions-package-update/runs/1918232749
