### PR TITLE
fix(node-version-control): exclude required files from .dockerignore and pass input args to ncu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@
 !src
 !test
 !types
+!.gitignore
+!.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,8 @@
 !docker
 !package.json
 !yarn.lock
+!tsconfig.json
+!tslint.json
+!src
+!test
+!types

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,4 +16,5 @@ chmod +x /this_env.sh
 
 cd /actions-package-update
 
-actions-package-update
+# ${INPUT_ARGS} are needed by ncu
+actions-package-update ${INPUT_ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,5 @@ sed -i '1s/^/\#\!\/bin\/sh -l\n/' env.sh
 
 # here we can make the construction of the image as customizable as we need
 # and if we need parameterizable values it is a matter of sending them as inputs
+# pass ${INPUT_ARGS} to docker run to match what github actions does to the original docker run command
 docker build -t actions-package-update --build-arg SET_NODE_VERSION="$SET_NODE_VERSION" . && docker run actions-package-update ${INPUT_ARGS}


### PR DESCRIPTION
**.dockerignore**

Add missing files that are required by the build and test packages
when we run npm or yarn prebublish when our repository is checkedout.

**docker/entrypoint.sh**

Pass input arguments to actions-package-update that will be needed
by ncu (node-check-update)

**entrypoint.sh**

Add a comment to why we are passing ${INPUT_ARGS} to docker run

**Test:** https://github.com/Ghustavh97/actions-package-update/runs/1925031392?check_suite_focus=true
**Pull Request Created:** https://github.com/Ghustavh97/actions-package-update/pull/3