### PR TITLE
fix: reset and clean repo before runnnig actions-package-update to prevent unwanted commits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,12 +8,3 @@
 # we need these files for node version control or build arguments
 !entrypoint.sh
 !docker
-!package.json
-!yarn.lock
-!tsconfig.json
-!tslint.json
-!src
-!test
-!types
-!.gitignore
-!.gitattributes

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,5 +16,9 @@ chmod +x /this_env.sh
 
 cd /actions-package-update
 
+# reset repo to original state after checkout to prevent committing unwanted files
+git reset --hard
+git clean -fdx
+
 # ${INPUT_ARGS} are needed by ncu
 actions-package-update ${INPUT_ARGS}


### PR DESCRIPTION
This pull request will fix a bug I found where the updater is now commiting its own files to a repo. This was caused by my previous pull requests (#19 #20) that moved the main Dockerfile to a different location in order to support node version control. After the fix only the package.json and yarn files should be updated and commited when an update happens.

### Before Fix

- Files where changed
- .dockerignore was modified by the updater

![wrong](https://user-images.githubusercontent.com/20132952/108416799-dfe49780-7237-11eb-8c91-429b5cede63a.PNG)

### After Fix

- Only 2 files where changed `package.json` and `yarn.lock`

![correct](https://user-images.githubusercontent.com/20132952/108416887-f985df00-7237-11eb-8a82-7aefd0123a8f.PNG)

[Test](https://github.com/Ghustavh97/actions-package-update/runs/1930151632?check_suite_focus=true)

[Pull Request](https://github.com/Ghustavh97/actions-package-update/pull/7) 

please ignore the `.github/workflows/schedule.yml` in files changed, it was cause by a force push I did after I took the sceenshots.

@taichi 
