### PR TITLE
Modify how to set the token on Octokit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,7 @@ export default class Processor {
 
   protected async newGitHub(config: Config, repo: giturl.GitUrl) {
     return new Octokit({
-      auth: `token ${config.get("token")}`,
+      auth: config.get("token"),
       userAgent: `${packageJson.name}/${packageJson.version}`,
       // for GHE
       baseUrl:


### PR DESCRIPTION
According to the official documentation, there is no need to add a prefix to the token on `auth` property: https://octokit.github.io/rest.js/v19#authentication.